### PR TITLE
Fix encryption key config check

### DIFF
--- a/clients/go/apiban-ipsets/config_empty_passwd_empty_key.json
+++ b/clients/go/apiban-ipsets/config_empty_passwd_empty_key.json
@@ -1,0 +1,13 @@
+{
+  "APIKEY": "abfd933a-bbbf-415c-916d-6586007a0968",
+  "LKID": "0",
+  "VERSION": "2",
+  "URL": "https://vbsec.d.intuitivelabs.com/api/",
+  "CHAIN": "BLOCKER",
+  "INTERVAL": "60s",
+  "FULL":"yes",
+  "BLACKLIST_TTL": "0s",
+  "STATE_FILENAME": "/tmp/apiban.state",
+  "PASSPHRASE": "",
+  "ENCRYPTION_KEY": ""
+}

--- a/clients/go/apiban-ipsets/config_no_key.json
+++ b/clients/go/apiban-ipsets/config_no_key.json
@@ -1,0 +1,12 @@
+{
+	"APIKEY": "*",
+	"LKID": "0",
+	"VERSION": "2",
+	"URL": "https://int19.d.intuitivelabs.com/api/",
+	"CHAIN": "BLOCKER",
+	"INTERVAL": "60s",
+	"FULL":"yes",
+    "BLACKLIST_TTL": "24h",
+    "STATE_FILENAME": "/tmp/apiban.state",
+    "ENCRYPTION_KEY": ""
+}

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -47,8 +47,8 @@ var (
 
 // anonymization objects
 var (
-	Ipcipher  cipher.Block
-	Validator anonymization.Validator
+	Ipcipher  cipher.Block            = nil
+	Validator anonymization.Validator = nil
 )
 
 // use insecure if configured - TESTING PURPOSES ONLY!
@@ -100,6 +100,10 @@ func InitEncryption(c *Config) {
 	)
 	if c == nil {
 		log.Fatalln("Cannot initialize anonymizer module. Exiting.")
+		return
+	}
+	if len(c.Passphrase) == 0 && len(c.EncryptionKey) == 0 {
+		log.Print("Neither passphrase nor encryption key provided; anonymization module is not initialized.")
 		return
 	}
 	if len(c.Passphrase) > 0 {

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -107,7 +107,7 @@ func InitEncryption(c *Config) {
 		anonymization.GenerateKeyFromPassphraseAndCopy(c.Passphrase,
 			anonymization.EncryptionKeyLen, encKey[:])
 		log.Print("encryption key: ", hex.EncodeToString(encKey[:]))
-	} else {
+	} else if len(c.EncryptionKey) > 0 {
 		// use the configured encryption key
 		// copy the configured key into the one used during realtime processing
 		if decoded, err := hex.DecodeString(c.EncryptionKey); err != nil {

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/intuitivelabs/anonymization"
 )
 
 var (
@@ -91,6 +93,11 @@ func LoadConfig(configFilename string) (*Config, error) {
 
 		if len(cfg.Passphrase) != 0 && len(cfg.EncryptionKey) != 0 {
 			return nil, fmt.Errorf("failed to read configuration from %s: both passphrase and encryption key are provided", loc)
+		}
+		// EncryptionKey must be either empty or contain 32 hex digits
+		if len(cfg.EncryptionKey) != 0 &&
+			len(cfg.EncryptionKey) != (anonymization.EncryptionKeyLen*2) {
+			return nil, fmt.Errorf("failed to read configuration from %s: invalid length for encryption key (when non-empty, encryption key must have a length of 32 hex digits)", loc)
 		}
 
 		fmt.Println("cfg: ", cfg)


### PR DESCRIPTION
- configured encryption key if not empty must have 32 hex digits
- if _both_ passphrase _and_ encryption key are empty the anonymization module is not initialized