### PR TITLE
Fix metadata ttl

### DIFF
--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -218,6 +218,9 @@ func Banned(key string, startFrom string, version string, baseUrl string) (*Entr
 		return out, nil
 	}
 
+	// store metadata
+	out.Metadata = e.Metadata
+
 	// Set the next ID and store it as state
 	out.ID = e.ID
 	GetState().Timestamp = e.ID

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -261,7 +261,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 		var err error
 		// try to get the ttl from the answers metada
 		if ttl, err = getTtlFromMetadata(entry.Metadata); err != nil {
-			log.Printf("failed to get blacklist ttl from metadata: %w", err)
+			log.Printf("failed to get blacklist ttl from metadata: %s", err)
 			ttl = 0
 		} else if ttl < 0 {
 			// negative ttl does not make sense
@@ -299,7 +299,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 		if kvCode, ok := s["encrypt"]; ok {
 			var err error
 			if ipStr, err = decryptIp(ipStr, kvCode); err != nil {
-				log.Printf("Error while decrypting ip %s: %w", ipStr, err)
+				log.Printf("Error while decrypting ip %s: %s", ipStr, err)
 				continue
 			}
 		}

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -78,6 +78,9 @@ var (
 	ErrEncryptFieldNotString = errors.New("encrypt field is not string in JSON")
 	ErrEncryptNoKey          = errors.New("IP encrypted but no passphrase or encryption key configured")
 	ErrEncryptWrongKey       = errors.New("IP encrypted but wrong passphrase or encryption key configured")
+	// API JSON errors
+	ErrJsonMetadataDefaultBlacklistTtlMissing  = errors.New(`"defaultBlacklistTtl not present in metadata`)
+	ErrJsonMetadataDefaultBlacklistTtlDataType = errors.New(`"defaultBlacklistTtl has wrong data type`)
 )
 
 // Entry describes a set of blocked IP addresses from APIBAN.org

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -82,8 +82,10 @@ func LoadConfig(configFilename string) (*Config, error) {
 		// Store the location of the config file so that we can update it later
 		cfg.filename = loc
 
-		// translate configuration parameters if needed
-		if t, err := time.ParseDuration(cfg.BlacklistTtl); err != nil {
+		if len(cfg.BlacklistTtl) == 0 {
+			cfg.blTtl = 0
+		} else if t, err := time.ParseDuration(cfg.BlacklistTtl); err != nil {
+			// translate configuration parameters if needed
 			return nil, fmt.Errorf("failed to read configuration from %s: %w", loc, err)
 		} else if t.Seconds() < 0 {
 			return nil, fmt.Errorf("failed to read configuration from %s: %w", loc, err)


### PR DESCRIPTION
When no `BLACKLIST_TTL` is specified in the config.json file, the one sent by the server in the JSON response' `metadata.defaultBlacklistTtl` should be used.
This is not working as expected; see:
https://github.com/intuitivelabs/intuitive-issues/issues/285