### PR TITLE
Config using jessevdk/go-flags

### DIFF
--- a/clients/go/apiban-ipsets/apiban-ipsets.go
+++ b/clients/go/apiban-ipsets/apiban-ipsets.go
@@ -183,12 +183,8 @@ func run(ctx context.Context, blset ipset.IPSet, apiconfig apiban.Config, sigCha
 	// Get list of banned ip's from APIBAN.org
 	fmt.Println("APIKEY", apiconfig.Apikey)
 	fmt.Println("URL", apiconfig.Url)
-	fmt.Println("TICK", apiconfig.Tick)
-	interval, err := time.ParseDuration(apiconfig.Tick)
-	if err != nil {
-		log.Print("Invalid interval format")
-		return err
-	}
+	fmt.Print("TICK", apiconfig.Tick)
+	interval := apiconfig.Tick
 
 	// start right away
 	currentTimeout := time.Duration(1 * time.Nanosecond)

--- a/clients/go/apiban-ipsets/apiban-ipsets.go
+++ b/clients/go/apiban-ipsets/apiban-ipsets.go
@@ -108,7 +108,6 @@ func main() {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Printf("FIXME: config after loading: %v\n", apiconfig)
 
 	// Open our Log
 	if apiconfig.LogFilename != "-" && apiconfig.LogFilename != "stdout" {

--- a/clients/go/apiban-ipsets/apiban-ipsets.go
+++ b/clients/go/apiban-ipsets/apiban-ipsets.go
@@ -47,10 +47,6 @@ var (
 	wg          sync.WaitGroup
 )
 
-const (
-	defaultId = "0"
-)
-
 func init() {
 }
 
@@ -128,41 +124,8 @@ func main() {
 		log.SetOutput(lf)
 	}
 
-	// if no APIKEY, exit
-	if apiconfig.Apikey == "" {
-		log.Fatalln("Invalid APIKEY. Exiting.")
-	}
-	// log config values
-	log.Print("CLI of FULL received, resetting LKID")
-
-	// allow cli of FULL to reset LKID to 100
-	if len(os.Args) > 1 {
-		arg1 := os.Args[1]
-		if arg1 == "FULL" {
-			log.Print("CLI of FULL received, resetting LKID")
-			apiconfig.Lkid = defaultId //"100"
-		}
-	} else {
-		log.Print("no command line arguments received")
-	}
-
-	// reset LKID to 100 if specified in config file
-	if apiconfig.Full == "yes" {
-		log.Print("FULL=yes in config file, resetting LKID")
-		apiconfig.Lkid = defaultId //"100"
-	}
-
-	// if no LKID, reset it to 100
-	if len(apiconfig.Lkid) == 0 {
-		log.Print("Resetting LKID")
-		apiconfig.Lkid = defaultId // "100"
-	} else {
-		log.Print("LKID:", apiconfig.Lkid)
-	}
-
-	// use default
-	if len(apiconfig.Chain) == 0 {
-		apiconfig.Chain = "BLOCKER"
+	if err := apiban.FixConfig(apiconfig); err != nil {
+		log.Fatalln(err)
 	}
 	log.Print("Chain:", apiconfig.Chain)
 

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -35,6 +35,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/intuitivelabs/anonymization"
 	"github.com/vladabroz/go-ipset/ipset"
@@ -233,7 +234,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 		//os.Exit(0)
 	}
 
-	ttl := int(GetConfig().BlacklistTtl)
+	ttl := int(GetConfig().BlacklistTtl / time.Second) // round-down to seconds
 	if ttl == 0 {
 		// try to get the ttl from the answers metada
 		metaTtl, ok := entry.Metadata["defaultBlacklistTtl"]
@@ -275,7 +276,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 				continue
 			}
 		}
-		err := blset.Add(ipStr, int(GetConfig().BlacklistTtl))
+		err := blset.Add(ipStr, ttl)
 		if err != nil {
 			log.Print("Adding IP to ipset failed. ", err.Error())
 		} else {

--- a/clients/go/apiban/apiban.go
+++ b/clients/go/apiban/apiban.go
@@ -233,7 +233,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 		//os.Exit(0)
 	}
 
-	ttl := GetConfig().blTtl
+	ttl := int(GetConfig().BlacklistTtl)
 	if ttl == 0 {
 		// try to get the ttl from the answers metada
 		metaTtl, ok := entry.Metadata["defaultBlacklistTtl"]
@@ -275,7 +275,7 @@ func ProcBannedResponse(entry *Entry, id string, blset ipset.IPSet) {
 				continue
 			}
 		}
-		err := blset.Add(ipStr, GetConfig().blTtl)
+		err := blset.Add(ipStr, int(GetConfig().BlacklistTtl))
 		if err != nil {
 			log.Print("Adding IP to ipset failed. ", err.Error())
 		} else {

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -5,6 +5,7 @@ import (
 	//"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -12,6 +13,10 @@ import (
 
 	"github.com/intuitivelabs/anonymization"
 	"github.com/jessevdk/go-flags"
+)
+
+const (
+	defaultId = "0"
 )
 
 var (
@@ -170,6 +175,33 @@ func LoadConfig() (*Config, error) {
 
 	return cfg, nil
 
+}
+
+func FixConfig(apiconfig *Config) error {
+	// if no APIKEY, exit
+	if apiconfig.Apikey == "" {
+		return fmt.Errorf("Invalid APIKEY. Exiting.")
+	}
+
+	// reset LKID to 100 if specified in config file
+	if apiconfig.Full == "yes" {
+		log.Print("FULL=yes in config file, resetting LKID")
+		apiconfig.Lkid = defaultId //"100"
+	}
+
+	// if no LKID, reset it to 100
+	if len(apiconfig.Lkid) == 0 {
+		log.Print("Resetting LKID")
+		apiconfig.Lkid = defaultId // "100"
+	} else {
+		log.Print("LKID:", apiconfig.Lkid)
+	}
+
+	// use default
+	if len(apiconfig.Chain) == 0 {
+		apiconfig.Chain = "BLOCKER"
+	}
+	return nil
 }
 
 // String converts the configuration data structure into a valid JSON string

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -156,7 +156,8 @@ func LoadConfig() (*Config, error) {
 	loc := cfg.filename
 	// translate configuration parameters if needed
 	if cfg.BlacklistTtl < time.Second {
-		return nil, fmt.Errorf("blacklist ttl under 1s in %q: %s\n", loc, cfg.BlacklistTtl)
+		log.Printf("blacklist ttl under 1s in %q: %s. Setting it to 0\n", loc, cfg.BlacklistTtl)
+		cfg.BlacklistTtl = 0
 	}
 
 	if len(cfg.Passphrase) != 0 && len(cfg.EncryptionKey) != 0 {

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	//"errors"
 	"fmt"
+	"io"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -36,10 +38,12 @@ type Config struct {
 	// passphrase used to generate encryption key for anonymization
 	Passphrase string `long:"PASSPHRASE" description:"password for encryption"`
 	// encryption key used for anonymization
-	EncryptionKey string `long:"ENCRYPTION_KEY" description:"encryption key as a hex string (password and key must not be set in the same time"`
+	EncryptionKey string `long:"ENCRYPTION_KEY" description:"encryption key as a hex string (password and key must not be set in the same time)"`
 
 	LogFilename string       `short:"l" long:"log" description:"log file or - for stdout"`
 	SetCfgFile  func(string) `short:"c" long:"config" description:"config file"`
+	Pdefaults   func()       `long:"defaults" description:"print default config"`
+	Pconfig     func(bool)   `long:"dump_cfg" optional:"1" optional-value:"0" description:"print current config, use true or 1 for condensed version"`
 
 	// black list ttl translated into seconds
 	blTtl    int
@@ -84,6 +88,19 @@ func LoadConfig() (*Config, error) {
 			return
 		}
 		cfg.filename = f // save current config name
+	}
+
+	// print default config
+	cfg.Pdefaults = func() {
+		dumpConfig(os.Stdout, DefaultConfig, true, false)
+		os.Exit(0)
+	}
+
+	// print current config (at the moment the command line parameter is
+	// encountered)
+	cfg.Pconfig = func(short bool) {
+		dumpConfig(os.Stdout, *cfg, !short, false)
+		os.Exit(0)
 	}
 
 	// parse command line
@@ -160,4 +177,45 @@ func (c *Config) String() string {
 	var b strings.Builder
 	json.NewEncoder(&b).Encode(c)
 	return b.String()
+}
+
+// dump config in a parseable config file format.
+func dumpConfig(w io.Writer, cfg Config, desc bool, altname bool) {
+	p := flags.NewParser(&cfg, flags.None)
+	for _, g := range p.Groups() {
+		fmt.Fprintf(w, "[%s]\n", g.ShortDescription)
+		prevDesc := false
+		for _, o := range g.Options() {
+			if !o.Hidden && o.Field().Type.Kind() != reflect.Func {
+				if desc && len(o.Description) != 0 {
+					if !prevDesc {
+						fmt.Fprintln(w)
+					}
+					fmt.Fprintf(w, "; %s\n", o.Description)
+				}
+				var name string
+				if !altname && len(o.LongName) != 0 {
+					name = o.LongName
+				} else if !altname && o.ShortName != 0 {
+					name = string(o.ShortName)
+				} else {
+					name = o.Field().Name
+				}
+				if o.Field().Type.Kind() == reflect.Slice {
+					s := reflect.ValueOf(o.Value())
+					for i := 0; i < s.Len(); i++ {
+						fmt.Fprintf(w, "%s = %v\n", name, s.Index(i))
+					}
+				} else {
+					fmt.Fprintf(w, "%s = %v\n", name, o.Value())
+				}
+				if desc && len(o.Description) != 0 {
+					fmt.Fprintln(w)
+					prevDesc = true
+				} else {
+					prevDesc = false
+				}
+			}
+		}
+	}
 }

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -21,9 +21,9 @@ const (
 
 var (
 	defaultConfigFilenames = [...]string{
-		"/etc/apiban-ipsets/config.json",
-		"config.json",
-		"/usr/local/bin/apiban/config.json",
+		"/etc/apiban-ipsets/config.ini",
+		"config.ini",
+		"/usr/local/bin/apiban/config.ini",
 	}
 )
 
@@ -79,6 +79,10 @@ func LoadConfig() (*Config, error) {
 	// set on config file option function
 	cfg.SetCfgFile = func(f string) {
 		cfgFileCnt++
+		if f == "" {
+			// force no config searching
+			return
+		}
 		if cfgFileCnt > 10 {
 			errCfgFile = fmt.Errorf("too many config files loaded"+
 				" (%d, current %w)", cfgFileCnt, f)
@@ -119,7 +123,7 @@ func LoadConfig() (*Config, error) {
 		// If we can determine the user configuration directory, try there
 		configDir, err := os.UserConfigDir()
 		if err == nil {
-			filenames = append(filenames, fmt.Sprintf("%s/apiban-ipsets/config.json", configDir))
+			filenames = append(filenames, fmt.Sprintf("%s/apiban-ipsets/config.ini", configDir))
 		}
 
 		// Add standard static locations

--- a/clients/go/apiban/config.go
+++ b/clients/go/apiban/config.go
@@ -2,7 +2,7 @@ package apiban
 
 import (
 	"encoding/json"
-	"errors"
+	//"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -25,10 +25,10 @@ type Config struct {
 	Apikey  string `long:"APIKEY" description:"api key"`
 	Lkid    string `long:"LKID" description:"lk id"`
 	Version string `long:"VERSION" description:"protocol version"`
-	Url     string `long:"URL" description:"ban list server url"`
-	Chain   string `long:"CHAIN" description:"ipset chain name"`
-	Tick    string `long:"INTERVAL" description:"tick interval"`
-	Full    string `long:"FULL"`
+	Url     string `long:"URL" description:"URL of blacklisted IPs DB"`
+	Chain   string `long:"CHAIN" description:"ipset chain name for matching entries"`
+	Tick    string `long:"INTERVAL" description:"interval for the list refresh"`
+	Full    string `long:"FULL" description:"yes/no - starting from scratch"`
 	// state filename
 	StateFilename string `long:"STATE_FILENAME" description:"filename for keeping the state"`
 	// ttl for the firewall DROP rules
@@ -38,77 +38,121 @@ type Config struct {
 	// encryption key used for anonymization
 	EncryptionKey string `long:"ENCRYPTION_KEY" description:"encryption key as a hex string (password and key must not be set in the same time"`
 
+	LogFilename string       `short:"l" long:"log" description:"log file or - for stdout"`
+	SetCfgFile  func(string) `short:"c" long:"config" description:"config file"`
+
 	// black list ttl translated into seconds
 	blTtl    int
 	filename string
 }
 
-var DefaultConfig = Config{}
+var DefaultConfig = Config{
+	Url:         "https://siem.intuitivelabs.com/api/",
+	Chain:       "BLOCKER",
+	LogFilename: "/var/log/apiban-ipsets.log",
+	Tick:        "60s",
+	Full:        "no",
+}
 
 // global configuration
-var config = &DefaultConfig
+var config = DefaultConfig
 
 func GetConfig() *Config {
-	return config
+	return &config
 }
 
 // LoadConfig attempts to load the APIBAN configuration file from various locations
-func LoadConfig(configFilename string) (*Config, error) {
+func LoadConfig() (*Config, error) {
 	var filenames []string
+	var errCfgFile error
 
-	// If we have a user-specified configuration file, use it preferentially
-	if configFilename != "" {
-		filenames = append(filenames, configFilename)
+	cfg := &config
+
+	cfgFileCnt := 0
+	// set on config file option function
+	cfg.SetCfgFile = func(f string) {
+		cfgFileCnt++
+		if cfgFileCnt > 10 {
+			errCfgFile = fmt.Errorf("too many config files loaded"+
+				" (%d, current %w)", cfgFileCnt, f)
+			return
+		}
+		fmt.Printf("loading config file %q ...\n", f)
+		if err := flags.IniParse(f, cfg); err != nil {
+			errCfgFile = fmt.Errorf("config file %q parsing failed: %w",
+				f, err)
+			return
+		}
+		cfg.filename = f // save current config name
 	}
 
-	// If we can determine the user configuration directory, try there
-	configDir, err := os.UserConfigDir()
-	if err == nil {
-		filenames = append(filenames, fmt.Sprintf("%s/apiban-ipsets/config.json", configDir))
+	// parse command line
+	if _, err := flags.Parse(cfg); err != nil {
+		return nil, fmt.Errorf("command line parsing failed: %w", err)
+	}
+	if errCfgFile != nil {
+		return nil, errCfgFile
 	}
 
-	// Add standard static locations
-	filenames = append(filenames, defaultConfigFilenames[:]...)
+	if cfgFileCnt == 0 {
+		// no config file on command line
+		// If we can determine the user configuration directory, try there
+		configDir, err := os.UserConfigDir()
+		if err == nil {
+			filenames = append(filenames, fmt.Sprintf("%s/apiban-ipsets/config.json", configDir))
+		}
 
-	for _, loc := range filenames {
+		// Add standard static locations
+		filenames = append(filenames, defaultConfigFilenames[:]...)
 
-		cfg := config
-		err := flags.IniParse(loc, cfg)
-		if err != nil {
-			if _, ok := err.(*os.PathError); ok {
-				// file not found
-				continue
+		for _, loc := range filenames {
+
+			err := flags.IniParse(loc, cfg)
+			if err != nil {
+				if _, ok := err.(*os.PathError); ok {
+					// file not found
+					continue
+				}
+				return nil, fmt.Errorf("failed to read configuration"+
+					" from %s: %w", loc, err)
 			}
-			return nil, fmt.Errorf("failed to read configuration from %s: %w", loc, err)
+
+			// Store the location of the config file so that we can update it
+			// later
+			cfg.filename = loc
+			cfgFileCnt++
+			break
 		}
-
-		// Store the location of the config file so that we can update it later
-		cfg.filename = loc
-
-		// translate configuration parameters if needed
-		if t, err := time.ParseDuration(cfg.BlacklistTtl); err != nil {
-			return nil, fmt.Errorf("failed to read configuration from %s: %w", loc, err)
-		} else if t.Seconds() < 0 {
-			return nil, fmt.Errorf("failed to read configuration from %s: %w", loc, err)
-		} else {
-			cfg.blTtl = int(t.Seconds())
-		}
-
-		if len(cfg.Passphrase) != 0 && len(cfg.EncryptionKey) != 0 {
-			return nil, fmt.Errorf("failed to read configuration from %s: both passphrase and encryption key are provided", loc)
-		}
-		// EncryptionKey must be either empty or contain 32 hex digits
-		if len(cfg.EncryptionKey) != 0 &&
-			len(cfg.EncryptionKey) != (anonymization.EncryptionKeyLen*2) {
-			return nil, fmt.Errorf("failed to read configuration from %s: invalid length for encryption key (when non-empty, encryption key must have a length of 32 hex digits)", loc)
-		}
-
-		fmt.Println("cfg: ", cfg)
-
-		return cfg, nil
+		// allow the no config file case, it could have been configured
+		// completely from command line
+		//  if cfgFileCnt == 0 {
+		//    return nil, errors.New("failed to locate configuration file")
+		//  }
 	}
 
-	return nil, errors.New("failed to locate configuration file")
+	loc := cfg.filename
+	// translate configuration parameters if needed
+	if t, err := time.ParseDuration(cfg.BlacklistTtl); err != nil {
+		return nil, fmt.Errorf("bad blacklist ttl in %q: %w", loc, err)
+	} else if t.Seconds() < 0 {
+		return nil, fmt.Errorf("blacklist ttl value too small  in %q: %w",
+			loc, err)
+	} else {
+		cfg.blTtl = int(t.Seconds())
+	}
+
+	if len(cfg.Passphrase) != 0 && len(cfg.EncryptionKey) != 0 {
+		return nil, fmt.Errorf("failed to read configuration from %s: both passphrase and encryption key are provided", loc)
+	}
+	// EncryptionKey must be either empty or contain 32 hex digits
+	if len(cfg.EncryptionKey) != 0 &&
+		len(cfg.EncryptionKey) != (anonymization.EncryptionKeyLen*2) {
+		return nil, fmt.Errorf("failed to read configuration from %s: invalid length for encryption key (when non-empty, encryption key must have a length of 32 hex digits)", loc)
+	}
+
+
+	return cfg, nil
+
 }
 
 // String converts the configuration data structure into a valid JSON string

--- a/clients/go/go.mod
+++ b/clients/go/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/coreos/go-iptables v0.4.5
 	github.com/intuitivelabs/anonymization v1.0.3-0.20210318230746-211d959e1e5f
+	github.com/jessevdk/go-flags v1.5.0
 	github.com/stretchr/testify v1.2.2
 	github.com/vladabroz/go-ipset v1.8.2
 )

--- a/clients/go/go.sum
+++ b/clients/go/go.sum
@@ -10,6 +10,8 @@ github.com/intuitivelabs/anonymization v1.0.3-0.20210318230746-211d959e1e5f h1:K
 github.com/intuitivelabs/anonymization v1.0.3-0.20210318230746-211d959e1e5f/go.mod h1:IPXLNFwTI7SvKipJ/EcLR8ma/6hDLHyFFagWVkd++gU=
 github.com/intuitivelabs/ipcrypt v1.1.0 h1:nLWT//mwecB7JC2/e7XSHasjRetJVqBnOCYrNW6WmQ4=
 github.com/intuitivelabs/ipcrypt v1.1.0/go.mod h1:1Tbk2GMxSflaUSwrQaFnMrg1VvTDM4JO3Jbh7RzPjSs=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
@@ -25,6 +27,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
- changed to .ini format (no more json)
-  everything can be also set from the command line
- help , print default config, dump current config
- case sensitive (so we should choose either upper or lower)

Help message:
Application Options:
      --APIKEY=         api key
      --LKID=           lk id
      --VERSION=        protocol version
      --URL=            URL of blacklisted IPs DB (default:
                        https://siem.intuitivelabs.com/api/)
      --CHAIN=          ipset chain name for matching entries (default: BLOCKER)
      --INTERVAL=       interval for the list refresh (default: 1m0s)
      --FULL=           yes/no - starting from scratch (default: no)
      --STATE_FILENAME= filename for keeping the state
      --BLACKLIST_TTL=  default blacklisted entry timeout in seconds
      --PASSPHRASE=     password for encryption
      --ENCRYPTION_KEY= encryption key as a hex string (password and key must
                        not be set in the same time)
  -l, --log=            log file or - for stdout (default:
                        /var/log/apiban-ipsets.log)
  -c, --config=         config file
      --defaults        print default config
      --dump_cfg=       print current config, use true or 1 for condensed
                        version

Help Options:
  -h, --help            Show this help message